### PR TITLE
Localizable errors, early return, specify maxSize

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const mime = require('simple-mime')('application/octect-stream')
 const imageProcess = require('./async/image-process')
 const blobify = require('./async/blobify')
 const publishBlob = require('./async/publish-blob')
+const MAX_SIZE = 5 * 1024 * 1024 // 5MB
+const MaxSizeError = require('./lib/max-size-error')
 
 module.exports = function blobFiles (files, server, opts, cb) {
   if (!files.length) return
@@ -16,7 +18,7 @@ module.exports = function blobFiles (files, server, opts, cb) {
     pull.asyncMap(buildFileDoc),
     pull.asyncMap(imageProcess({ stripExif, resize, quality })),
     pull.asyncMap(blobify),
-    pull.asyncMap(publishBlob({ server, isPrivate })),
+    pull.asyncMap(publishBlob({ server, isPrivate, maxSize: MAX_SIZE })),
     pull.drain(
       result => {
         // this catches the maxSize errors from publishBlob
@@ -42,3 +44,6 @@ function buildFileDoc (file, cb) {
   }
   reader.readAsDataURL(file)
 }
+
+// re-export error so that it can be used to check the type
+module.exports.MaxSizeError = MaxSizeError

--- a/lib/max-size-error.js
+++ b/lib/max-size-error.js
@@ -1,0 +1,20 @@
+class MaxSizeError extends Error {
+  constructor ({ fileName, fileSize, maxFileSize }) {
+    super(`${fileName} (${humanSize(fileSize)}) is larger than the allowed limit of ${humanSize(maxFileSize)}`)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MaxSizeError)
+    }
+
+    this.fileName = fileName
+    this.fileSize = fileSize
+    this.maxFileSize = maxFileSize
+    this.code = 'EXCEEDS_MAX_SIZE'
+  }
+}
+
+module.exports = MaxSizeError
+
+function humanSize (size) {
+  return (Math.ceil(size / (1024 * 1024) * 10) / 10) + ' MB'
+}


### PR DESCRIPTION
_This is a bit of a grab bag of my latest changes to ssb-blob-files for patchwork. The code was a bit tangled up, so I'm pushing as one big ball LOL (it's all good stuff though!)_

## localisable error messages

**The PR adds a custom error type `MaxSizeError` with `fileName`, `fileSize` and `maxFileSize` properties.** 

These can be used when localising the error message, for example:

```js
if (err instanceof blobFiles.MaxSizeError) {
  warningMessage.set([
    i18n('{{name}} ({{size}}) is larger than the allowed limit of {{max_size}}', {
      'name': err.fileName,
      'size': humanSize(err.fileSize),
      'max_size': humanSize(err.maxFileSize)
    })
  ])
}
```

## early return

Currently if you attach a very large file (100 MB or so), this may lock up and even crash the client due to the use of `reader.readAsDataURL(file)` which loads the entire file into an in memory string. If we want to support large files later, we'll need to update the code to use streams. Since we only allow 5 MB files, we should just error before trying to process the file instead.

**The PR adds an early return if `resize` is not specified and the `fileSize` exceeds `maxSize`**.

## specify maxSize

**And finally, this adds an option to specify `maxSize`** since as @regular points out, this is configurable in sbot!

---

closes #3 
maybe also #4 ??
see also https://github.com/ssbc/patchwork/issues/893
