### PR TITLE
Fix `{ stripExif }` to support boolean `true`

### DIFF
--- a/async/image-process.js
+++ b/async/image-process.js
@@ -9,7 +9,7 @@ module.exports = function imageProcess (opts) {
     if (doc.mimeType === 'image/jpeg') {
       try {
         orientation = getOrientation(doc.data)
-        if (resolve(stripExif) === 'true') doc.data = removeExif(doc.data, orientation)
+        if (resolve(stripExif) === true) doc.data = removeExif(doc.data, orientation)
       } catch (ex) {
         console.log('exif exception:', ex)
       }


### PR DESCRIPTION
This function accepts `stripExif` as a boolean but compares against a
string literal `'true'`, which means that EXIF metadata was never
stripped from images that were processed by this module.

Resolves #6 