### PR TITLE
Maintain aspect ratio on resize

### DIFF
--- a/async/image-process.js
+++ b/async/image-process.js
@@ -46,29 +46,25 @@ function getImage (data, cb) {
   image.onload = () => cb(image)
   image.src = data
   image.style.display = 'block'
-  if (image.complete) cb(image)
+  //if (image.complete) cb(image)
 }
 
 function doResize (image, width, height) {
-  var imageHeight = image.height
-  var imageWidth = image.width
+  if (image.height < height && image.width < width)
+    return image
 
-  var multiplier = (height / image.height)
-  if (multiplier * imageWidth < width) {
-    multiplier = width / image.width
-  }
+  var ratioX = width / image.width
+  var ratioY = height / image.height
+  var ratio = Math.min(ratioX, ratioY)
 
-  var finalWidth = imageWidth * multiplier
-  var finalHeight = imageHeight * multiplier
-
-  var offsetX = (finalWidth - width) / 2
-  var offsetY = (finalHeight - height) / 2
+  var finalWidth = image.width * ratio
+  var finalHeight = image.height * ratio
 
   var canvas = document.createElement('canvas')
-  canvas.width = width
-  canvas.height = height
+  canvas.width = finalWidth
+  canvas.height = finalHeight
   var ctx = canvas.getContext('2d')
-  ctx.drawImage(image, -offsetX, -offsetY, finalWidth, finalHeight)
+  ctx.drawImage(image, 0, 0, finalWidth, finalHeight)
   return canvas
 }
 

--- a/async/image-process.js
+++ b/async/image-process.js
@@ -1,4 +1,5 @@
 const piexif = require('piexifjs')
+const resizeDimensions = require('../lib/resize-dimensions')
 const { resolve } = require('../utils')
 
 module.exports = function imageProcess (opts) {
@@ -53,18 +54,15 @@ function doResize (image, width, height) {
   if (image.height < height && image.width < width)
     return image
 
-  var ratioX = width / image.width
-  var ratioY = height / image.height
-  var ratio = Math.min(ratioX, ratioY)
-
-  var finalWidth = image.width * ratio
-  var finalHeight = image.height * ratio
+  const final = resizeDimensions(width, height, image)
 
   var canvas = document.createElement('canvas')
-  canvas.width = finalWidth
-  canvas.height = finalHeight
+  canvas.width = final.width
+  canvas.height = final.height
+
   var ctx = canvas.getContext('2d')
-  ctx.drawImage(image, 0, 0, finalWidth, finalHeight)
+  ctx.drawImage(image, final.x, final.y, final.width, final.height)
+
   return canvas
 }
 

--- a/lib/resize-dimensions.js
+++ b/lib/resize-dimensions.js
@@ -1,0 +1,12 @@
+module.exports = (width, height, image) => {
+  var ratioX = width / image.width
+  var ratioY = height / image.height
+  var ratio = Math.min(ratioX, ratioY)
+
+  return {
+    x: 0,
+    y: 0,
+    width: image.width * ratio,
+    height: image.height * ratio
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-blob-files",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -350,6 +350,12 @@
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -372,6 +378,12 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
     },
     "deglob": {
       "version": "2.1.1",
@@ -926,6 +938,15 @@
         "del": "^2.0.2",
         "graceful-fs": "^4.1.2",
         "write": "^0.2.1"
+      }
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
       }
     },
     "foreach": {
@@ -1844,6 +1865,15 @@
         }
       }
     },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3.4"
+      }
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -2155,6 +2185,17 @@
         "strip-ansi": "^4.0.0"
       }
     },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -2216,6 +2257,70 @@
         "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
+      }
+    },
+    "tape": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.11.0.tgz",
+      "integrity": "sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.4",
+        "has": "~1.0.3",
+        "inherits": "~2.0.4",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.6.0",
+        "resolve": "~1.11.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "object-inspect": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+          "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "split-buffer": "^1.0.0"
   },
   "devDependencies": {
-    "standard": "^12.0.1"
+    "standard": "^12.0.1",
+    "tape": "^4.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "handle processing and addition of files to the blob store",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/index.js"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,15 @@
+const test = require('tape')
+const resizeDimensions = require('../lib/resize-dimensions')
+
+test('image resize', (t) => {
+  const image = { width: 100, height: 100 }
+  const newSize = 10
+  const final = resizeDimensions(newSize, newSize, image)
+
+  t.equal(final.width - final.x, newSize, 'correct width')
+  t.equal(final.height - final.y, newSize, 'correct height')
+
+  t.equal(final.x, 0, 'no width crop')
+  t.equal(final.y, 0, 'no height crop')
+  t.end()
+})


### PR DESCRIPTION
This is probably not meant to be merge but instead more meant as a discussion.

When I started using this library I thought resize would maintain aspect ratio and that width and height meant the max-width and max-height of the image. But it seems that the way it behaves now is more like, if you specify a width and height smaller than the image, then you will just a sort of zoomed version of the middle of the image with this width/height.

Secondly I snucked in a small change because I noticed that the callback was triggered twice, once, onload and another time as complete.